### PR TITLE
add basic homematic support

### DIFF
--- a/wirehome.device_adapters.homematic.sensor/1.0.0/description.md
+++ b/wirehome.device_adapters.homematic.sensor/1.0.0/description.md
@@ -1,0 +1,17 @@
+# Summary
+This adapter wraps a generic Homematic device and watches a property as the sensor value.
+It requires a configured Homematic CCU and the wirehome.services.homematic.ccu service to be installed.
+
+# Configuration
+
+Example:
+
+```json
+{
+    "config":
+    {
+        "address": "0012888395C123:1",  // the address of the device from the CCU webinterface
+        "property": "ACTUAL_TEMPERATURE"  // the name of the property that should be watched
+    }
+}
+```

--- a/wirehome.device_adapters.homematic.sensor/1.0.0/meta.json
+++ b/wirehome.device_adapters.homematic.sensor/1.0.0/meta.json
@@ -1,0 +1,4 @@
+{
+  "caption": "Homematic Sensor",
+  "author": "pfriedrich"
+}

--- a/wirehome.device_adapters.homematic.sensor/1.0.0/releaseNotes.md
+++ b/wirehome.device_adapters.homematic.sensor/1.0.0/releaseNotes.md
@@ -1,0 +1,1 @@
+Initial release.

--- a/wirehome.device_adapters.homematic.sensor/1.0.0/script.py
+++ b/wirehome.device_adapters.homematic.sensor/1.0.0/script.py
@@ -1,0 +1,55 @@
+SERVICE_ID = "wirehome.services.homematic.ccu"
+
+config = {}
+
+
+def process_adapter_message(message):
+    message_type = message.get("type", None)
+
+    if message_type == "initialize":
+        return __initialize__()
+    if message_type == "destroy":
+        return __destroy__()
+    return {
+        "type": "exception.not_supported",
+        "origin_type": type
+    }
+
+
+def __initialize__():
+    result = {"type": "success"}
+
+    global subscription_uid
+    subscription_uid = wirehome.context["component_uid"] + "->homematic.ccu.event.device_state_changed"
+
+    address = config.get("address")
+    property_name = config.get("property")
+
+    filter = {
+        "type": "homematic.ccu.event.device_state_changed",
+        "address": address,
+        "property": property_name
+    }
+
+    wirehome.message_bus.subscribe(subscription_uid, filter, __gateway_manager_callback__)
+
+    initial_value = wirehome.services.invoke(SERVICE_ID, "get_device_value", address, property_name)
+    __update_value(initial_value)
+
+    return result
+
+
+def __destroy__():
+    wirehome.message_bus.unsubscribe(subscription_uid)
+
+
+def __gateway_manager_callback__(message):
+    new_state = message.get("new", None)
+    __update_value(new_state)
+
+
+def __update_value(new_state):
+    wirehome.publish_adapter_message({
+        "type": "value_updated",
+        "value": new_state
+    })

--- a/wirehome.device_adapters.homematic.window/1.0.0/description.md
+++ b/wirehome.device_adapters.homematic.window/1.0.0/description.md
@@ -1,0 +1,22 @@
+# Summary
+This adapter wraps a generic Homematic device and watches a property as the sensor value.
+It requires a configured Homematic CCU and the wirehome.services.homematic.ccu service to be installed.
+
+# Configuration
+
+Example:
+
+```json
+{
+    "config":
+    {
+        // the address of the window contact from the CCU webinterface
+        "address": "0012888395C123:1",
+
+        // optional, the name of the property that should be watched.
+        // defaults to STATE, overwriting to WINDOW_STATE allows to watch
+        // a contact that is linked directly to a thermostat.
+        "property": "STATE"
+    }
+}
+```

--- a/wirehome.device_adapters.homematic.window/1.0.0/meta.json
+++ b/wirehome.device_adapters.homematic.window/1.0.0/meta.json
@@ -1,0 +1,4 @@
+{
+  "caption": "Homematic door/window contact",
+  "author": "pfriedrich"
+}

--- a/wirehome.device_adapters.homematic.window/1.0.0/releaseNotes.md
+++ b/wirehome.device_adapters.homematic.window/1.0.0/releaseNotes.md
@@ -1,0 +1,1 @@
+Initial release.

--- a/wirehome.device_adapters.homematic.window/1.0.0/script.py
+++ b/wirehome.device_adapters.homematic.window/1.0.0/script.py
@@ -1,0 +1,63 @@
+SERVICE_ID = "wirehome.services.homematic.ccu"
+
+config = {}
+
+
+def process_adapter_message(message):
+    message_type = message.get("type", None)
+
+    if message_type == "initialize":
+        return __initialize__()
+    if message_type == "destroy":
+        return __destroy__()
+    return {
+        "type": "exception.not_supported",
+        "origin_type": type
+    }
+
+
+def __initialize__():
+    result = {"type": "success"}
+
+    global subscription_uid
+    subscription_uid = wirehome.context["component_uid"] + "->homematic.ccu.event.device_state_changed"
+
+    address = config.get("address")
+    property_name = config.get("property", "STATE")
+
+    subscription_filter = {
+        "type": "homematic.ccu.event.device_state_changed",
+        "address": address,
+        "property": property_name
+    }
+
+    wirehome.message_bus.subscribe(subscription_uid, subscription_filter, __gateway_manager_callback__)
+
+    initial_value = wirehome.services.invoke(SERVICE_ID, "get_device_value", address, property_name)
+    __update_value(initial_value)
+
+    return result
+
+
+def __destroy__():
+    wirehome.message_bus.unsubscribe(subscription_uid)
+
+
+def __gateway_manager_callback__(message):
+    new_value = message.get("new", None)
+
+    __update_value(new_value)
+
+
+def __update_value(new_value):
+    new_state = ""
+
+    if new_value == 1:
+        new_state = "open"
+    elif new_value == 0:
+        new_state = "closed"
+
+    wirehome.publish_adapter_message({
+        "type": "state_changed",
+        "new_state": new_state
+    })

--- a/wirehome.services.homematic.ccu/1.0.0/description.md
+++ b/wirehome.services.homematic.ccu/1.0.0/description.md
@@ -1,0 +1,13 @@
+# Summary
+Connects to the XML-RPC endpoint of Homematic CCU and allows access to the device states.
+
+# Installation
+- enable XML-RPC in the CCU Firewall configuration.
+
+# Configuration
+```
+{
+    "ip": "[IP of the CCU]",
+    "port": "[PORT of the XML-RPC server]" // 2010 for Homematic IP devices, 2001 for BidCos-RF, 2000 for BidCos-Wired`
+}
+```

--- a/wirehome.services.homematic.ccu/1.0.0/description.md
+++ b/wirehome.services.homematic.ccu/1.0.0/description.md
@@ -1,5 +1,6 @@
 # Summary
-Connects to the XML-RPC endpoint of Homematic CCU and allows access to the device states.
+Connects to the XML-RPC endpoint of a Homematic CCU and allows access to the device states.  
+Offers an XML-RPC server to receive events from the CCU.
 
 # Installation
 - enable XML-RPC in the CCU Firewall configuration.
@@ -7,7 +8,9 @@ Connects to the XML-RPC endpoint of Homematic CCU and allows access to the devic
 # Configuration
 ```
 {
-    "ip": "[IP of the CCU]",
-    "port": "[PORT of the XML-RPC server]" // 2010 for Homematic IP devices, 2001 for BidCos-RF, 2000 for BidCos-Wired`
+    "ccu_ip": "[IP of the CCU]",
+    "ccu_port": "[PORT of the CCU's XML-RPC server]", // 2010 for Homematic IP devices, 2001 for BidCos-RF, 2000 for BidCos-Wired`
+    "rpc_ip": "[IP of the Wirehome host]",
+    "rpc_port": "[PORT of Wirehome's XML-RPC Server]" // choose one
 }
 ```

--- a/wirehome.services.homematic.ccu/1.0.0/meta.json
+++ b/wirehome.services.homematic.ccu/1.0.0/meta.json
@@ -1,0 +1,4 @@
+{
+  "caption": "Homematic CCU",
+  "author": "pfriedrich"
+}

--- a/wirehome.services.homematic.ccu/1.0.0/releaseNotes.md
+++ b/wirehome.services.homematic.ccu/1.0.0/releaseNotes.md
@@ -1,0 +1,1 @@
+Initial release.

--- a/wirehome.services.homematic.ccu/1.0.0/script.py
+++ b/wirehome.services.homematic.ccu/1.0.0/script.py
@@ -1,0 +1,88 @@
+import xmlrpclib
+from threading import Thread
+from SimpleXMLRPCServer import SimpleXMLRPCServer
+
+config = {}
+
+
+def initialize():
+    global ccu_url, _gateway_is_connected
+
+    ccu_ip = config["ccu_ip"]
+    ccu_port = config["ccu_port"]
+    ccu_url = "http://{ip}:{port}".format(ip=ccu_ip, port=ccu_port)
+
+    _gateway_is_connected = False
+
+    # configuration of the xml-rpc server used to receive events from the ccu
+    rpc_ip = config["rpc_ip"]
+    rpc_port = int(config["rpc_port"])
+    server = ServerThread(rpc_ip, rpc_port)
+    server.start()
+
+    # register server with ccu
+    __get_proxy__().init("http://{ip}:{port}".format(ip=rpc_ip, port=rpc_port), "wirehome")
+
+
+def start():
+    pass
+
+
+def stop():
+    pass
+
+
+def get_device_values(address):
+    return __get_proxy__().getParamset(address, "VALUES")
+
+
+def get_device_value(address, name):
+    return __get_proxy__().getValue(address, name)
+
+
+def __get_proxy__():
+    global ccu_url
+    return xmlrpclib.ServerProxy(ccu_url)
+
+
+class XMLRPCHandler:
+    def __init__(self):
+        pass
+
+    def event(self, interface_id, address, value_key, value):
+        self.__fire_event(address, value_key, value)
+        return unicode("")
+
+    def listDevices(self, _):
+        return []
+
+    def newDevices(self, _):
+        return unicode("")
+
+    def newDevice(self, _):
+        # it is necessary to return a unicode string here. otherwise, the ccu just won't answer anymore
+        return unicode("")
+
+    def deleteDevices(self, ):
+        return unicode("")
+
+    def __fire_event(self, address, property_name, new_value):
+        wirehome.message_bus.publish({
+            "type": "homematic.ccu.event.device_state_changed",
+            "address": address,
+            "property": property_name,
+            "new": new_value
+        })
+
+
+class ServerThread(Thread):
+    def __init__(self, ip, port):
+        Thread.__init__(self)
+
+        self.server = SimpleXMLRPCServer((ip, port), logRequests=False)
+        self.server.register_instance(XMLRPCHandler())
+        self.server.register_introspection_functions()
+        self.server.register_multicall_functions()
+
+    def run(self):
+        self.server.serve_forever()


### PR DESCRIPTION
This PR adds a service that connects to the Homematic CCU and
a) allows a devices state to be read
b) creates a XML-RPC server and registers it with the CCU, allowing for event-based communication instead of polling

Adapters for a generic sensor and a shutter contact are included as well.